### PR TITLE
Continuous beam example

### DIFF
--- a/examples/Continuous_Beam/ContinuousBeam.csproj
+++ b/examples/Continuous_Beam/ContinuousBeam.csproj
@@ -35,12 +35,8 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="Dlubal.RFEMWebServiceLibrary" Version="6.4.7" />
     <PackageReference Include="NLog" Version="5.0.4" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\source_code\RFEMWebServiceLibrary\RFEMWebServiceLibrary.csproj" />
-    <ProjectReference Include="..\..\source_code\RSTABWebServiceLibrary\RSTABWebServiceLibrary.csproj" />
   </ItemGroup>
 
 </Project>

--- a/examples/Continuous_Beam/ContinuousBeam.csproj
+++ b/examples/Continuous_Beam/ContinuousBeam.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Dlubal.RFEMWebServiceLibrary" Version="6.4.7" />
+    <PackageReference Include="Dlubal.RFEMWebServiceLibrary" Version="6.4.8" />
     <PackageReference Include="NLog" Version="5.0.4" />
   </ItemGroup>
 

--- a/examples/Continuous_Beam/Program.cs
+++ b/examples/Continuous_Beam/Program.cs
@@ -499,8 +499,9 @@ namespace ContinuousBeam
                 Console.WriteLine("Number of volume elements: " + mesh_Statistics.solid_3D_finite_elements);
                 #endregion
 #endif
-                calculation_message[] calculationMessages = model.calculate_all(true);
-                if (calculationMessages.Length != 0)
+                calculation_result calculationResult = model.calculate_all(true);
+
+                if (calculationResult.succeeded == false)
                 {
                 }
                 else

--- a/examples/Continuous_Beam/Program.cs
+++ b/examples/Continuous_Beam/Program.cs
@@ -591,8 +591,12 @@ namespace ContinuousBeam
                 Console.WriteLine("Node reactions:");
                 foreach (var item in nodeReactions)
                 {
+                    if (item.no == 6 | item.no == 20)
+                    {
+                        continue;
+                    }
                     Console.WriteLine("Row no {0}\t Description {1}", item.no, item.description);
-                    Console.WriteLine("note corresponding loading {0}\t px {1}\t py {2}\t pz {3}\t mx {4}\t my {5}\t mz {6}\t label {7}\t", item.row.node_comment_corresponding_loading.ToString(), item.row.support_force_p_x.value.ToString(), item.row.support_force_p_y.value.ToString(), item.row.support_force_p_z.value.ToString(), item.row.support_moment_m_x.value.ToString(), item.row.support_moment_m_y.ToString(), item.row.support_moment_m_z.ToString(), item.row.support_forces_label);
+                    Console.WriteLine("node corresponding loading \t px {0}\t py {1}\t pz {2}\t mx {3}\t my {4}\t mz {5}\t label \t",item.row.support_force_p_x.value.ToString(), item.row.support_force_p_y.value.ToString(), item.row.support_force_p_z.value.ToString(), item.row.support_moment_m_x.value.ToString(), item.row.support_moment_m_y.ToString(), item.row.support_moment_m_z.ToString());
                 }
                 #endregion
 
@@ -631,7 +635,7 @@ namespace ContinuousBeam
 
                 //save the model before closing
                 model.save(CurrentDirectory + @"\testmodels\");
-                application.close_model(0, true);
+                application.close_model(0, false);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
# Description

I added the example "continuous beam" in the folder "examples". It's a continuous concrete beam with user input for the number of fields, span and a continuous member load. The example contains two loadcases - selfweight and continuous member load. The example uses classes from "RFEMWebServiceLibrary". Compared to PR#30 I updated the example to the new webservice version.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual Testing.

**Test Configuration**:
* RFEM / RSTAB version: 6.04.0008
* .Net SDK: .NET 6.0


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
